### PR TITLE
Add API forwarder lambda

### DIFF
--- a/services/request-forwarder-api-key/.env-template
+++ b/services/request-forwarder-api-key/.env-template
@@ -1,0 +1,2 @@
+# set via env variables in config (just here for documentation purposes or local tests)
+ACCESS_TOKEN=

--- a/services/request-forwarder-api-key/lambda.js
+++ b/services/request-forwarder-api-key/lambda.js
@@ -1,0 +1,33 @@
+export const handler = async (event, context) => {
+    const url = 'https://api.tenderly.co/api/v1/account/boba/project/gnosis-multisig-frontend/simulate'
+    const apiKey = process.env.ACCESS_TOKEN
+
+    try {
+        /*console.log('## ENVIRONMENT VARIABLES: ' + serialize(process.env))
+        console.log('## CONTEXT: ' + serialize(context))
+        console.log('## EVENT: ' + serialize(event))*/
+
+
+        const response = await fetch(url, {
+            method: 'POST',
+            headers: {
+                'Content-Type': 'application/json',
+                'X-Access-Key': apiKey,
+            },
+            body: JSON.stringify(event),
+        })
+
+        return await response.json()
+
+    } catch (error) {
+        return {
+            statusCode: 500,
+            msg: 'Unable to forward request: ' + error,
+        }
+    }
+};
+
+
+var serialize = function(object) {
+    return JSON.stringify(object, null, 2)
+}

--- a/services/request-forwarder-api-key/lambda.js
+++ b/services/request-forwarder-api-key/lambda.js
@@ -1,4 +1,11 @@
+import warmer from "lambda-warmer";
+
 export const handler = async (event, context) => {
+
+    // if a warming event
+    if (await warmer(event)) return 'warmed'
+    // else proceed with handler logic
+
     const url = 'https://api.tenderly.co/api/v1/account/boba/project/gnosis-multisig-frontend/simulate'
     const apiKey = process.env.ACCESS_TOKEN
 
@@ -22,12 +29,7 @@ export const handler = async (event, context) => {
     } catch (error) {
         return {
             statusCode: 500,
-            msg: 'Unable to forward request: ' + error,
+            msg: 'Unable to send: ' + error,
         }
     }
 };
-
-
-var serialize = function(object) {
-    return JSON.stringify(object, null, 2)
-}

--- a/services/request-forwarder-api-key/package.json
+++ b/services/request-forwarder-api-key/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "api-forwarder",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "lambda-warmer": "^2.0.0"
+  }
+}


### PR DESCRIPTION
## What it solves

Resolves #1 

## How this PR fixes it
Adds lambda function for AWS that attaches a Tenderly AccessKey in the Http headers to forward the request to the simulate endpoint. 

## How to test it
Can be tested with event defined in #1 by using the test function on AWS lambda, API gateway and via curl. 
